### PR TITLE
Scrum 57 implement api health ready endpoints

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -4,9 +4,9 @@ from flask_cors import CORS
 from .auth import auth_bp
 from .format import format_bp
 from .forum import forum_bp
+from .status import status_bp
 from .thesis import thesis_bp
 from .user import user_bp
-from .status import status_bp
 
 
 def register_routes(app):
@@ -39,6 +39,7 @@ def register_routes(app):
                 )
                 response.headers["Access-Control-Allow-Credentials"] = "true"
                 return response
+
         app.register_blueprint(status_bp)
         app.register_blueprint(auth_bp)
         app.register_blueprint(user_bp)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -6,6 +6,7 @@ from .format import format_bp
 from .forum import forum_bp
 from .thesis import thesis_bp
 from .user import user_bp
+from .status import status_bp
 
 
 def register_routes(app):
@@ -38,7 +39,7 @@ def register_routes(app):
                 )
                 response.headers["Access-Control-Allow-Credentials"] = "true"
                 return response
-
+        app.register_blueprint(status_bp)
         app.register_blueprint(auth_bp)
         app.register_blueprint(user_bp)
         app.register_blueprint(thesis_bp)

--- a/backend/app/routes/status.py
+++ b/backend/app/routes/status.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify
 
+
 status_bp = Blueprint("status", __name__, url_prefix="/api/status")
 
 
@@ -7,9 +8,68 @@ status_bp = Blueprint("status", __name__, url_prefix="/api/status")
 def health_check():
     """
     Health Check Endpoint
-    Returns a basic 200 OK response to indicate the app is running.
+    Verifies the application's health by checking memory, CPU, and required environment variables
+    based on the current environment (development, testing, production).
     """
-    return jsonify({"status": "healthy"}), 200
+    import psutil  # For system-level resource checks
+    import os
+    try:
+        # Check memory usage
+        memory_info = psutil.virtual_memory()
+        if memory_info.percent > 85:
+            return jsonify({"status": "unhealthy", "error": "High memory usage"}), 503
+
+        # Check CPU usage
+        cpu_usage = psutil.cpu_percent(interval=0.5)
+        if cpu_usage > 90:
+            return jsonify({"status": "unhealthy", "error": "High CPU usage"}), 503
+
+        # Environment-specific checks
+        flask_env = os.getenv("FLASK_ENV", "development")
+        missing_env_vars = []
+
+        if flask_env == "development":
+            required_env_vars = [
+                "DEV_DATABASE_ENGINE",
+                "DEV_DATABASE_NAME",
+                "DEV_DATABASE_USER",
+                "DEV_DATABASE_PASSWORD",
+                "DEV_DATABASE_HOST",
+            ]
+        elif flask_env == "testing":
+            required_env_vars = [
+                "TEST_DATABASE_ENGINE",
+                "TEST_DATABASE_NAME",
+            ]
+        elif flask_env == "production":
+            required_env_vars = [
+                "PROD_DATABASE_ENGINE",
+                "PROD_DATABASE_NAME",
+                "PROD_DATABASE_USER",
+                "PROD_DATABASE_PASSWORD",
+                "PROD_DATABASE_HOST",
+            ]
+        else:
+            return jsonify(
+                {"status": "unhealthy", "error": "Unknown FLASK_ENV value"}
+            ), 503
+
+        # Validate environment variables
+        missing_env_vars = [var for var in required_env_vars if not os.getenv(var)]
+        if missing_env_vars:
+            return jsonify(
+                {
+                    "status": "unhealthy",
+                    "error": "Missing required environment variables",
+                    "details": missing_env_vars,
+                }
+            ), 503
+
+        # If all checks pass
+        return jsonify({"status": "healthy", "environment": flask_env}), 200
+
+    except Exception as e:
+        return jsonify({"status": "unhealthy", "error": "Unknown error", "details": str(e)}), 500
 
 
 @status_bp.route("/ready", methods=["GET"])
@@ -40,7 +100,7 @@ def readiness_check():
     except redis.exceptions.RedisError as re:
         return (
             jsonify({"status": "unready", "error": "Redis Error", "details": str(re)}),
-            500,
+            503,
         )
 
     except PeeweeException as pe:
@@ -48,7 +108,7 @@ def readiness_check():
             jsonify(
                 {"status": "unready", "error": "Database Error", "details": str(pe)}
             ),
-            500,
+            503,
         )
 
     except Exception as e:
@@ -56,3 +116,11 @@ def readiness_check():
             jsonify({"status": "unready", "error": "Unknown Error", "details": str(e)}),
             500,
         )
+
+@status_bp.route("/alive", methods=["GET"])
+def alive_check():
+    """
+    Alive Check Endpoint
+    Confirms that the application is running and able to respond.
+    """
+    return jsonify({"status": "alive"}), 200

--- a/backend/app/routes/status.py
+++ b/backend/app/routes/status.py
@@ -1,0 +1,45 @@
+from flask import Blueprint, jsonify
+
+
+status_bp = Blueprint("status", __name__, url_prefix="/api/status")
+
+@status_bp.route("/health", methods=["GET"])
+def health_check():
+    """
+    Health Check Endpoint
+    Returns a basic 200 OK response to indicate the app is running.
+    """
+    return jsonify({"status": "healthy"}), 200
+
+
+@status_bp.route("/ready", methods=["GET"])
+def readiness_check():
+    """
+    Readiness Check Endpoint
+    Ensures that the app's dependencies are ready.
+    """
+    from ..utils.db import database_proxy
+    from ..utils.redis_helper import get_redis_client
+    from peewee import PeeweeException
+    import redis
+
+    try:
+        # Example: Check database connection
+        if database_proxy.is_closed():
+            database_proxy.connect()
+        database_proxy.execute_sql("SELECT 1")  # A simple query to validate DB connection
+
+        # Check Redis connection
+        redis_client = get_redis_client()
+        redis_client.ping()  # Simple command to validate Redis connection
+
+        return jsonify({"status": "ready"}), 200
+    except redis.exceptions.RedisError as re:
+        return jsonify({"status": "unready", "error": "Redis Error", "details": str(re)}), 500
+
+    except PeeweeException as pe:
+        return jsonify({"status": "unready", "error": "Database Error", "details": str(pe)}), 500
+
+    except Exception as e:
+        return jsonify({"status": "unready", "error": "Unknown Error", "details": str(e)}), 500
+

--- a/backend/app/routes/status.py
+++ b/backend/app/routes/status.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify
 
-
 status_bp = Blueprint("status", __name__, url_prefix="/api/status")
+
 
 @status_bp.route("/health", methods=["GET"])
 def health_check():
@@ -18,16 +18,19 @@ def readiness_check():
     Readiness Check Endpoint
     Ensures that the app's dependencies are ready.
     """
+    import redis
+    from peewee import PeeweeException
+
     from ..utils.db import database_proxy
     from ..utils.redis_helper import get_redis_client
-    from peewee import PeeweeException
-    import redis
 
     try:
         # Example: Check database connection
         if database_proxy.is_closed():
             database_proxy.connect()
-        database_proxy.execute_sql("SELECT 1")  # A simple query to validate DB connection
+        database_proxy.execute_sql(
+            "SELECT 1"
+        )  # A simple query to validate DB connection
 
         # Check Redis connection
         redis_client = get_redis_client()
@@ -35,11 +38,21 @@ def readiness_check():
 
         return jsonify({"status": "ready"}), 200
     except redis.exceptions.RedisError as re:
-        return jsonify({"status": "unready", "error": "Redis Error", "details": str(re)}), 500
+        return (
+            jsonify({"status": "unready", "error": "Redis Error", "details": str(re)}),
+            500,
+        )
 
     except PeeweeException as pe:
-        return jsonify({"status": "unready", "error": "Database Error", "details": str(pe)}), 500
+        return (
+            jsonify(
+                {"status": "unready", "error": "Database Error", "details": str(pe)}
+            ),
+            500,
+        )
 
     except Exception as e:
-        return jsonify({"status": "unready", "error": "Unknown Error", "details": str(e)}), 500
-
+        return (
+            jsonify({"status": "unready", "error": "Unknown Error", "details": str(e)}),
+            500,
+        )

--- a/backend/app/tests/test_status.py
+++ b/backend/app/tests/test_status.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    """
+    Fixture to mock environment variables for testing.
+    """
+    def set_env(env_vars):
+        for key, value in env_vars.items():
+            monkeypatch.setenv(key, value)
+
+    return set_env
+
+
+def test_status_health_ok(client, mock_env):
+    """
+    Test the /api/status/health endpoint when everything is healthy.
+    """
+    mock_env({
+        "FLASK_ENV": "development",
+        "DEV_DATABASE_ENGINE": "mysql",
+        "DEV_DATABASE_NAME": "thesis_app_dev",
+        "DEV_DATABASE_USER": "thesis_dev",
+        "DEV_DATABASE_PASSWORD": "dev_password",
+        "DEV_DATABASE_HOST": "localhost"
+    })
+
+    with patch("psutil.virtual_memory") as mock_memory, \
+            patch("psutil.cpu_percent") as mock_cpu:
+        mock_memory.return_value = type("svmem", (object,), {"percent": 12.5})
+        mock_cpu.return_value = 25
+
+        response = client.get("/api/status/health")
+        assert response.status_code == 200
+        assert response.json["status"] == "healthy"
+        assert response.json["environment"] == "development"
+
+
+def test_status_health_high_memory(client, mock_env):
+    """
+    Test the /api/status/health endpoint with high memory usage.
+    """
+    mock_env({
+        "FLASK_ENV": "production",
+        "PROD_DATABASE_ENGINE": "mysql",
+        "PROD_DATABASE_NAME": "prod_db",
+        "PROD_DATABASE_USER": "prod_user",
+        "PROD_DATABASE_PASSWORD": "prod_password",
+        "PROD_DATABASE_HOST": "cloud-mysql-url"
+    })
+
+    with patch("psutil.virtual_memory") as mock_memory, \
+            patch("psutil.cpu_percent") as mock_cpu:
+        mock_memory.return_value = type("svmem", (object,), {"percent": 93.75})
+        mock_cpu.return_value = 25
+
+        response = client.get("/api/status/health")
+        assert response.status_code == 503
+        assert response.json["status"] == "unhealthy"
+        assert response.json["error"] == "High memory usage"
+
+
+def test_status_health_high_cpu(client, mock_env):
+    """
+    Test the /api/status/health endpoint with high CPU usage.
+    """
+    mock_env({
+        "FLASK_ENV": "production",
+        "PROD_DATABASE_ENGINE": "mysql",
+        "PROD_DATABASE_NAME": "prod_db",
+        "PROD_DATABASE_USER": "prod_user",
+        "PROD_DATABASE_PASSWORD": "prod_password",
+        "PROD_DATABASE_HOST": "cloud-mysql-url"
+    })
+
+    with patch("psutil.virtual_memory") as mock_memory, \
+            patch("psutil.cpu_percent") as mock_cpu:
+        mock_memory.return_value = type("svmem", (object,), {"percent": 12.5})
+        mock_cpu.return_value = 95
+
+        response = client.get("/api/status/health")
+        assert response.status_code == 503
+        assert response.json["status"] == "unhealthy"
+        assert response.json["error"] == "High CPU usage"
+
+
+def test_status_health_missing_env_vars(client, mock_env):
+    """
+    Test the /api/status/health endpoint with missing environment variables.
+    """
+    mock_env({
+        "FLASK_ENV": "testing",
+        "TEST_DATABASE_ENGINE": "sqlite"
+        # Missing TEST_DATABASE_NAME
+    })
+
+    with patch("psutil.virtual_memory") as mock_memory, \
+            patch("psutil.cpu_percent") as mock_cpu:
+        mock_memory.return_value = type("svmem", (object,), {"percent": 12.5})
+        mock_cpu.return_value = 25
+
+        response = client.get("/api/status/health")
+        assert response.status_code == 503
+        assert response.json["status"] == "unhealthy"
+        assert response.json["error"] == "Missing required environment variables"
+        assert "TEST_DATABASE_NAME" in response.json["details"]
+
+
+def test_status_alive_ok(client):
+    """
+    Test the /api/status/alive endpoint when the application is alive.
+    """
+    response = client.get("/api/status/alive")
+    assert response.status_code == 200
+    assert response.json["status"] == "alive"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -69,6 +69,7 @@ pip-tools==7.4.1
 platformdirs==4.3.6
 pluggy==1.5.0
 prompt_toolkit==3.0.48
+psutil==6.1.1
 ptyprocess==0.7.0
 pure_eval==0.2.3
 pycparser==2.22


### PR DESCRIPTION
### Changes proposed in this PR ###
- [X] Summary of the change(s) made.

Introduce the `/api/status` endpoint to handle `/health` and `/ready` checks. 

### Why are these changes needed? ###
- [X] Explanation of the problem(s) this solves.

Introducing the application into production with use with ALBs, there's should be a typical `/health` and `/ready` endpoint for the API service as this is best practice.

### How I've tested this PR ###
- [X] Details of tests added or updated (e.g., `pytest`, `npm test`).

Added `backend/app/tests/test_status.py` tests:
- test_status_health_ok
- test_status_health_high_memory
- test_status_health_high_cpu
- test_status_health_missing_env_vars
- test_status_alive_ok

### How I expect reviewers to test this PR ###
- [X] Instructions on how reviewers can manually test this change (e.g., `curl` commands, UI flows).

Run `python -m cli.main run` to start backend locally, and manually run `curl http://127.0.0.1:8557/api/status/<health,ready,alive>` to view proper API response returns.

### Impact Analysis ###
- [X] Any areas of the code that are at risk due to these changes.

- None

### Checklist ###
- [X] Required tests added/updated
  - [X] Backend API: `pytest` tests added to `backend/app/tests`
